### PR TITLE
:zap: Be the first eventListener

### DIFF
--- a/src/chord_listener.ts
+++ b/src/chord_listener.ts
@@ -27,8 +27,8 @@ export class ChordListener {
 			// of modifiers only, handle it now.
 			this.chordPress(event);
 		};
-		document.addEventListener("keydown", this.handleKeydown);
-		document.addEventListener("keyup", this.handleKeyup);
+		document.addEventListener("keydown", this.handleKeydown, { capture: true });
+		document.addEventListener("keyup", this.handleKeyup, { capture: true });
 	}
 
 	chordPress = (event: KeyboardEvent) => {
@@ -42,7 +42,7 @@ export class ChordListener {
 	};
 
 	destruct = () => {
-		document.removeEventListener("keydown", this.handleKeydown);
-		document.removeEventListener("keyup", this.handleKeyup);
+		document.removeEventListener("keydown", this.handleKeydown, { capture: true });
+		document.removeEventListener("keyup", this.handleKeyup, { capture: true });
 	};
 }


### PR DESCRIPTION
- Sets the capture property to true
- This will prioritize the sequence hotkey plugin over sub apps like webviews of the surfing plugin or excalidraw hotkeys
- fixes #22 
- implements #26 

This is a breaking change as it changes the behaviour slightly and it may break existing workflows of some users.